### PR TITLE
Add dark mode and UX improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,16 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Portfolio of Mazen Balasta, software engineer and USAF veteran" />
+    <meta name="keywords" content="Mazen Balasta, portfolio, software engineer" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "name": "Mazen Balasta",
+        "url": "https://mazenbalasta.netlify.app/"
+      }
+    </script>
     <title>Mazen Balasta</title>
   </head>
   <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,9 @@ import Projects from './components/Projects'
 import Resume from './components/Resume'
 import Contact from './components/Contact'
 import Footer from './components/Footer'
+import About from './components/About'
+import DarkModeToggle from './components/DarkModeToggle'
+import ScrollToTop from './components/ScrollToTop'
 
 function App() {
 
@@ -14,13 +17,16 @@ function App() {
         <Sidenav />
         <Main />
       </div>
-      <div className='bg-gray-600'>
+      <div className='bg-gray-600 dark:bg-gray-700'>
         <Work />
+        <About />
         <Projects />
         <Resume />
         <Contact />
         <Footer />
       </div>
+      <DarkModeToggle />
+      <ScrollToTop />
     </>
   )
 }

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { FaGithubSquare, FaLinkedin } from 'react-icons/fa';
+
+const About = () => (
+  <section id='about' className='max-w-[1040px] m-auto md:pl-20 p-4 py-16'>
+    <h1 className='text-4xl font-bold text-center text-[#001b5e] dark:text-blue-300'>About Me</h1>
+    <p className='py-8 text-gray-100 font-semibold'>
+      I am a software engineer with a background in the U.S. Air Force. My passion lies in creating efficient and user friendly applications.
+      I enjoy learning new technologies and constantly improving my skill set.
+    </p>
+    <div className='flex justify-center gap-4'>
+      <a href='https://github.com/mazenbalasta' target='_blank' rel='noopener noreferrer'>
+        <FaGithubSquare className='text-3xl hover:text-[#001b5e]' />
+      </a>
+      <a href='https://www.linkedin.com/in/mazen-balasta/' target='_blank' rel='noopener noreferrer'>
+        <FaLinkedin className='text-3xl hover:text-[#001b5e]' />
+      </a>
+    </div>
+  </section>
+);
+
+export default About;

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -3,29 +3,29 @@ import React from 'react'
 const Contact = () => {
   return (
     <div id='contact' className='max-w-[1040px] m-auto md:pl-20 p-4 py-16'>
-        <h1 className='py-4 text-4xl font-bold text-center text-[#001b5e]'>Contact Me</h1>
+        <h1 className='py-4 text-4xl font-bold text-center text-[#001b5e] dark:text-blue-300'>Contact Me</h1>
         <form action="https://getform.io/f/pbqgnwnb" method='POST' encType='multipart/form-data'>
             <div className='grid md:grid-cols-2 gap-4 w-full py-2'>
                 <div className='flex flex-col'>
                     <label className='uppercase text-sm text-gray-100 font-semibold py-2'>Name</label>
-                    <input className='border-2 rounded-lg p-3 flex border-gray-300' type="text" name='name' />
+                    <input className='border-2 rounded-lg p-3 flex border-gray-300' type="text" name='name' required />
                 </div>
                 <div className='flex flex-col'>
                     <label className='uppercase text-sm text-gray-100 font-semibold py-2'>Phone Number</label>
-                    <input className='border-2 rounded-lg p-3 flex border-gray-300' type="text" name='phone' />
+                    <input className='border-2 rounded-lg p-3 flex border-gray-300' type="text" name='phone' required />
                 </div>
             </div>
             <div className='flex flex-col py-2'>
                 <label className='uppercase text-sm text-gray-100 font-semibold py-2'>Email</label>
-                <input className='border-2 rounded-lg p-3 flex border-gray-300' type="email" name="email" />
+                <input className='border-2 rounded-lg p-3 flex border-gray-300' type="email" name="email" required />
             </div>
             <div className='flex flex-col py-2'>
                 <label className='uppercase text-sm text-gray-100 font-semibold py-2'>Subject</label>
-                <input className='border-2 rounded-lg p-3 flex border-gray-300' type="text" name="subject" />
+                <input className='border-2 rounded-lg p-3 flex border-gray-300' type="text" name="subject" required />
             </div>
             <div className='flex flex-col py-2'>
                 <label className='uppercase text-sm text-gray-100 font-semibold py-2'>Message</label>
-                <textarea className='border-2 rounded-lg p-3 border-gray-300' rows="10" name='message'></textarea>
+                <textarea className='border-2 rounded-lg p-3 border-gray-300' rows="10" name='message' required></textarea>
             </div>
             <button className='bg-[#001b5e] text-gray-100 mt-4 w-full p-4 rounded-lg hover:bg-[#001b3e]'>
                 Send Message

--- a/src/components/DarkModeToggle.jsx
+++ b/src/components/DarkModeToggle.jsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+
+const DarkModeToggle = () => {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    if (dark) {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, [dark]);
+
+  return (
+    <button
+      onClick={() => setDark(!dark)}
+      className='fixed bottom-5 right-5 z-50 bg-gray-300 dark:bg-gray-800 p-2 rounded-full shadow-md hover:scale-110 transition'
+      aria-label='Toggle Dark Mode'
+    >
+      {dark ? '🌙' : '☀️'}
+    </button>
+  );
+};
+
+export default DarkModeToggle;

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const Footer = () => (
-  <footer className='bg-gray-800 text-gray-300 text-center py-4'>
+  <footer className='bg-gray-800 dark:bg-gray-900 text-gray-300 text-center py-4'>
     <p className='text-sm'>© {new Date().getFullYear()} Mazen Balasta. All rights reserved.</p>
   </footer>
 );

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -13,10 +13,10 @@ const Main = () => {
         src="https://images.unsplash.com/photo-1510915228340-29c85a43dcfe?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
         alt="Background"
       />
-      <div className='w-full h-screen absolute top-0 left-0 bg-gradient-to-r from-black via-transparent to-black/70'>
+      <div className='w-full h-screen absolute top-0 left-0 bg-gradient-to-r from-black via-transparent to-black/70 dark:from-gray-900 dark:to-gray-900/70'>
         <div className='max-w-[700px] m-auto h-full w-full flex flex-col justify-center lg:items-start items-center'>
-          <h1 className='text-white sm:text-5xl text-4xl font-bold'>I'm Mazen Balasta</h1>
-          <h2 className='text-white flex sm:text-3xl text-2xl pt-4'>
+          <h1 className='text-white dark:text-blue-300 sm:text-5xl text-4xl font-bold'>I'm Mazen Balasta</h1>
+          <h2 className='text-white dark:text-blue-200 flex sm:text-3xl text-2xl pt-4'>
             I'm a
             <TypeAnimation
               sequence={[
@@ -35,7 +35,7 @@ const Main = () => {
               repeat={Infinity}
             />
           </h2>
-          <div className='text-white flex justify-between pt-6 max-w-[200px] w-full'>
+          <div className='text-white dark:text-blue-300 flex justify-between pt-6 max-w-[200px] w-full'>
             <a href="https://github.com/mazenbalasta" target="_blank" rel="noopener noreferrer">
               <FaGithubSquare className='cursor-pointer' size={20} />
             </a>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -5,9 +5,16 @@ import nlbImg from '../assets/nlb.png';
 import zcdImg from '../assets/zcd.png';
 import portfolioImg from '../assets/portfolio.png';
 
+const projectData = [
+  { img: nlbImg, title: 'Never Left Behind', tech: 'Vite + React', category: 'web', modal: 'Nlb' },
+  { img: zcdImg, title: "Zen's Car Dealership", tech: 'React Js', category: 'web', modal: 'Zcd' },
+  { img: portfolioImg, title: 'Portfolio', tech: 'Vite + React', category: 'web', modal: 'Portfolio' },
+];
+
 const Projects = () => {
   const [showModal, setShowModal] = useState(false);
   const [selectedProject, setSelectedProject] = useState(null);
+  const [filter, setFilter] = useState('all');
 
   const openModal = (project) => {
     setSelectedProject(project);
@@ -18,16 +25,35 @@ const Projects = () => {
     setShowModal(false);
   };
 
+  const filteredProjects =
+    filter === 'all'
+      ? projectData
+      : projectData.filter((p) => p.category === filter);
+
   return (
     <div id='projects' className='max-w-[1040px] m-auto md:pl-20 p-4 py-16'>
-      <h1 className='text-4xl font-bold text-center text-[#001b5e]'>Recent Projects</h1>
+      <h1 className='text-4xl font-bold text-center text-[#001b5e] dark:text-blue-300'>Recent Projects</h1>
       <p className='text-center py-8 text-gray-100 font-semibold'>
       Celebrate my latest completed projects showcasing expertise in software engineering, illustrating proficiency in managing, designing, and implementing innovative solutions for diverse technical challenges.
       </p>
+      <div className='flex justify-center gap-4 pb-8'>
+        <button
+          className={`px-3 py-1 rounded-full border ${filter === 'all' ? 'bg-[#001b5e] text-white' : 'bg-gray-200 dark:bg-gray-700'}`}
+          onClick={() => setFilter('all')}
+        >
+          All
+        </button>
+        <button
+          className={`px-3 py-1 rounded-full border ${filter === 'web' ? 'bg-[#001b5e] text-white' : 'bg-gray-200 dark:bg-gray-700'}`}
+          onClick={() => setFilter('web')}
+        >
+          Web
+        </button>
+      </div>
       <div className='grid sm:grid-cols-1 lg:grid-cols-2 gap-12'>
-        <ProjectItem img={nlbImg} title='Never Left Behind' project='Vite + React' onClick={() => openModal('Nlb')} />
-        <ProjectItem img={zcdImg} title="Zen's Car Dealership" project='React Js' onClick={() => openModal('Zcd')} />
-        <ProjectItem img={portfolioImg} title='Portfolio' project='Vite + React' onClick={() => openModal('Portfolio')} />
+        {filteredProjects.map((p) => (
+          <ProjectItem key={p.title} img={p.img} title={p.title} project={p.tech} onClick={() => openModal(p.modal)} />
+        ))}
       </div>
 
       {showModal && selectedProject === 'Nlb' && <NlbModal closeModal={closeModal} />}

--- a/src/components/Resume.jsx
+++ b/src/components/Resume.jsx
@@ -7,7 +7,7 @@ const Resume = () => {
   return (
     <div id='resume' className='flex flex-col justify-center items-center xsm:p-4 md:pl-20'>
       <div>
-        <h1 className='text-4xl font-bold text-center text-[#001b5e]'>Download My Resume</h1>
+        <h1 className='text-4xl font-bold text-center text-[#001b5e] dark:text-blue-300'>Download My Resume</h1>
       </div>
       <div className='flex flex-col items-center text-center py-8'>
         <p className="mb-8 font-bold text-lg text-gray-100">Click the image below to download my resume:</p>

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+
+const ScrollToTop = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      if (window.pageYOffset > 300) {
+        setVisible(true);
+      } else {
+        setVisible(false);
+      }
+    };
+    window.addEventListener('scroll', toggleVisibility);
+    return () => window.removeEventListener('scroll', toggleVisibility);
+  }, []);
+
+  const scrollUp = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  if (!visible) return null;
+
+  return (
+    <button
+      onClick={scrollUp}
+      className='fixed bottom-5 left-5 z-50 bg-gray-300 dark:bg-gray-800 p-2 rounded-full shadow-md hover:scale-110 transition'
+      aria-label='Scroll to Top'
+    >
+      ↑
+    </button>
+  );
+};
+
+export default ScrollToTop;

--- a/src/components/Work.jsx
+++ b/src/components/Work.jsx
@@ -44,7 +44,7 @@ const data = [
 const Work = () => {
   return (
     <div id='work' className='max-w-[1040px] m-auto md:pl-20 p-4 py-16'>
-        <h1 className='text-4xl font-bold text-center text-[#001b5e]'>Experiences</h1>
+        <h1 className='text-4xl font-bold text-center text-[#001b5e] dark:text-blue-300'>Experiences</h1>
         {data.map((item, idx) => (
             <WorkItem
                 key={idx}

--- a/src/index.css
+++ b/src/index.css
@@ -5,3 +5,7 @@
 *{
     scroll-behavior: smooth;
 }
+
+body {
+    @apply bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
   "./index.html",
   "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary
- enable dark mode support
- add dark mode toggle and scroll-to-top components
- create About section with social links
- add project filtering controls
- enhance contact form with required fields
- update headings for dark mode colors
- add SEO meta tags and structured data

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68424db4a36483299bf32151a5164915